### PR TITLE
rename Conquest Assault (alt.)

### DIFF
--- a/content/hosting/maps.md
+++ b/content/hosting/maps.md
@@ -46,7 +46,7 @@ weight: 8
 | Conquest | `ConquestSmall0` |
 | Conquest Assault 64 | `ConquestAssaultLarge0` |
 | Conquest Assault | `ConquestAssaultSmall0` |
-| Conquest Assault (alt.) | `ConquestAssaultSmall1` |
+| Conquest Assault: Day 2 | `ConquestAssaultSmall1` |
 | Rush | `RushLarge0` |
 | Squad Rush | `SquadRush0` |
 | Squad Deathmatch | `SquadDeathMatch0` |


### PR DESCRIPTION
![Screenshot_18](https://user-images.githubusercontent.com/56718716/95692728-33aaf880-0c28-11eb-81bc-9677668c64b1.jpg)

Renaming `Conquest Assault (alt.)` to `Conquest Assault: Day 2` because that's the name.